### PR TITLE
Add gitleaks to the project

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -14,13 +14,9 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        # No inputs are required; the action uses the built‑in token automatically.
-        # If you want to customise the scan, use the supported inputs (e.g., config, report_format, etc.).
-        # Example of a supported input:
-        #   with:
-        #     config: .gitleaks.toml
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description
Add gitleaks to the project to prevent hardcoded credentials to be committed in the public.

this PR partially resolves #12  

### What was implemented ?
- [x] added `gitleaks.yml` file, the workflow will fail each time you try to add sensitive information to the project's code.
- [x] installed gitleaks locally using chocolatey and tested the repository for leaks, and no leaks were found.

### What could be done further ?
- [ ] `gitleaks.toml` file may be added to the project's root folder for gitleaks configurations. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Added an automated "Gitleaks Scan" CI workflow to run on pushes and pull requests targeting main.
  - Configured workflow permissions to allow repository read access and PR annotations.
  - Uses the repository token to run the Gitleaks action; no sample configs or custom inputs are included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->